### PR TITLE
Docker image build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.7-alpine
 RUN apk add --update nodejs nodejs-npm docker
 RUN docker --version
 
-RUN pip install --upgrade pip click  gunicorn docker-compose
+RUN pip install --upgrade pip click gunicorn
+# Workaround, will not build with latest docker-compose (1.24)
+RUN pip install --upgrade docker-compose==1.23.2
 
 RUN mkdir -p /app/config
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ will run pystacker at http://localhost:10080 and data directory(where stacks con
 
 ## Development mode
 
-* clone this reposotory
+* clone this repository
 * copy `pystacker-backend/config/app.dist.yml` to `pystacker-backend/config/app.yml`
 * install pystacker-backend package to your python environment(virualenv recommended): `pip install -e pystacker-backend`
 * install JS requirements: `cd pystacker-front && npm install`


### PR DESCRIPTION
After update of docker-compose (1.24) docker image can not be built. This workaround fix the problem.